### PR TITLE
Add new blog post for GSoC - 'LaTeX Citations' tab

### DIFF
--- a/_posts/2019-08-06-GSoC - LatexCitationsTab.md
+++ b/_posts/2019-08-06-GSoC - LatexCitationsTab.md
@@ -7,11 +7,11 @@ color: white
 ---
 
 Hello!
-Since our last publication, we have worked hard to carry out this second major update.
-The tool that allows you to search for citations in LaTeX files is ready, fully functional and integrated into the project, in its latest version.
+Since our last post, we have worked hard to carry out this second major update.
+The tool that allows you to search for citations in LaTeX files is ready, fully functional and integrated into the development version, in its latest version.
 
-All code has been reviewed and modified to improve its performance and prevent possible errors.
-Regarding the user interface, we have added a tab to the entry editor, improved the aesthetics and renamed the tool: **Search for Citations in LaTeX files**.
+The code has been reviewed and modified to improve its performance and prevent possible errors.
+Regarding the user interface, we have added a tab to the entry editor, improved the aesthetics and renamed the tool to **Search for Citations in LaTeX files**.
 
 Now we need your feedback!
 We will take it into account to keep improving this feature.
@@ -24,7 +24,7 @@ We will take it into account to keep improving this feature.
 We added a new tab to the entry editor to search for citations to the active entry in the LaTeX file directory (it can be configured in the _Library properties_ dialog).
 The new tab can be disabled in the preferences.
 
-That is how it works:
+This is how it works:
 
 !['LaTeX Citations' tab](https://user-images.githubusercontent.com/12954316/62509787-d68a0a80-b80c-11e9-84f5-f894f965dc9e.gif)
 

--- a/_posts/2019-08-06-GSoC - LatexCitationsTab.md
+++ b/_posts/2019-08-06-GSoC - LatexCitationsTab.md
@@ -1,0 +1,49 @@
+---
+title: "Google Summer of Code 2019: 'LaTeX Citations' tab"
+id: gsoc-2019-latex-citations-tab
+author: "[JabRef Developers](https://github.com/JabRef/jabref/blob/master/DEVELOPERS)"
+bg: jabref-font
+color: white
+---
+
+Hello!
+Since the last publication, we have been working hard to accomplish this second major update.
+The tool that allows you to search for citations in LaTeX files is ready, fully functional and integrated with the project, in its latest version.
+
+All code has been reviewed and modified to improve its performance and prevent possible errors.
+Regarding the user interface, we have added a tab in the entry editor, improved the aesthetics and renamed the tool: **Search for Citations in LaTeX files**.
+
+Now we need your feedback!
+We will take it into account to keep improving the feature.
+[Forum](http://discourse.jabref.org/t/project-latex-integration-please-give-us-your-feedback/1660) |
+[GitHub](https://github.com/JabRef/jabref/pull/5155) |
+[Gitter](https://gitter.im/JabRef/jabref)
+
+## _LaTeX Citations_ tab
+
+We added a new tab to the entry editor to search for citations to the active entry in the LaTeX file directory (it can be configured in the _Library properties_ dialog).
+The new tab can be disabled in the preferences.
+
+That is how it works:
+
+!['LaTeX Citations' tab](https://user-images.githubusercontent.com/12954316/62509787-d68a0a80-b80c-11e9-84f5-f894f965dc9e.gif)
+
+### An improved back-end
+- Optimized parsing performance
+- Non-existing nested files are skipped
+- Better exception handling
+
+### The new tab
+- New tab in the entry editor: _LaTeX Citations_
+- This tab could be disabled in the entry editor preferences
+- A progress indicator appears while parsing
+- Search cancellation if the active entry is changed (background tasks)
+- Parsed files are stored when the tool is run for the first time (much better performance)
+- The current search path is shown at the bottom, next to a button to change the LaTeX file directory
+- Error logging and handling (some of them are shown in the entry editor)
+
+### A custom user interface controller for listing citations
+- Citations list view is the same for dialog tool and tab
+- Context of citations, instead of the full line (which is shown as a tooltip)
+- Changed absolute file path to a relative one, from the search path
+- New icons and styles for context, file path and position (line and column) of a citation

--- a/_posts/2019-08-06-GSoC - LatexCitationsTab.md
+++ b/_posts/2019-08-06-GSoC - LatexCitationsTab.md
@@ -7,16 +7,16 @@ color: white
 ---
 
 Hello!
-Since the last publication, we have been working hard to accomplish this second major update.
-The tool that allows you to search for citations in LaTeX files is ready, fully functional and integrated with the project, in its latest version.
+Since our last publication, we have worked hard to carry out this second major update.
+The tool that allows you to search for citations in LaTeX files is ready, fully functional and integrated into the project, in its latest version.
 
 All code has been reviewed and modified to improve its performance and prevent possible errors.
-Regarding the user interface, we have added a tab in the entry editor, improved the aesthetics and renamed the tool: **Search for Citations in LaTeX files**.
+Regarding the user interface, we have added a tab to the entry editor, improved the aesthetics and renamed the tool: **Search for Citations in LaTeX files**.
 
 Now we need your feedback!
-We will take it into account to keep improving the feature.
+We will take it into account to keep improving this feature.
 [Forum](http://discourse.jabref.org/t/project-latex-integration-please-give-us-your-feedback/1660) |
-[GitHub](https://github.com/JabRef/jabref/pull/5155) |
+[GitHub](https://github.com/JabRef/jabref/issues/5002) |
 [Gitter](https://gitter.im/JabRef/jabref)
 
 ## _LaTeX Citations_ tab
@@ -29,21 +29,21 @@ That is how it works:
 !['LaTeX Citations' tab](https://user-images.githubusercontent.com/12954316/62509787-d68a0a80-b80c-11e9-84f5-f894f965dc9e.gif)
 
 ### An improved back-end
-- Optimized parsing performance
-- Non-existing nested files are skipped
-- Better exception handling
+- Optimized parsing performance.
+- Non-existent nested files are skipped.
+- Better exception handling.
 
 ### The new tab
-- New tab in the entry editor: _LaTeX Citations_
-- This tab could be disabled in the entry editor preferences
-- A progress indicator appears while parsing
-- Search cancellation if the active entry is changed (background tasks)
-- Parsed files are stored when the tool is run for the first time (much better performance)
-- The current search path is shown at the bottom, next to a button to change the LaTeX file directory
-- Error logging and handling (some of them are shown in the entry editor)
+- A _LaTeX Citations_ tab has been added to the entry editor.
+- This tab can be disabled in the _Entry editor_ preferences.
+- A progress indicator appears while parsing.
+- Current search is cancelled if other entry is selected.
+- Parsed files are stored when the tool is run for the first time (better performance).
+- The current search path is shown at the bottom, next to a button to set the LaTeX file directory.
+- A user-friendly error logging and handling has also been implemented.
 
 ### A custom user interface controller for listing citations
-- Citations list view is the same for dialog tool and tab
-- Context of citations, instead of the full line (which is shown as a tooltip)
-- Changed absolute file path to a relative one, from the search path
-- New icons and styles for context, file path and position (line and column) of a citation
+- Citations list view is the same for dialog tool and tab.
+- Context of citations, instead of the whole line of text (which is shown as a tooltip).
+- Absolute file path has been changed into a relative one, from the search path.
+- New icons and styles for context, file path and position (line and column) of a citation.


### PR DESCRIPTION
Here is a draft for the next blog post.

I still have to review the text and fix spelling errors, but what do you think about it?

---
title: "Google Summer of Code 2019: 'LaTeX Citations' tab"
id: gsoc-2019-latex-citations-tab
---