### PR TITLE
Added thumbs.db to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ CNAME
 
 # IntelliJ
 *.iml
+
+# Windows
+thumbs.db


### PR DESCRIPTION
## Description 
`thumbs.db` is a windows directory cache file which sometimes gets pushed to repos, comes in commits, and can trouble other users. Now windows users can send PRs without having to worry about `thumbs.db`.