### PR TITLE
State external contributors

### DIFF
--- a/_posts/2022-12-18-JabRef5-9.md
+++ b/_posts/2022-12-18-JabRef5-9.md
@@ -30,4 +30,6 @@ In case you notice any bugs or problems, please browse through our [bug tracker]
 
 Following external contributors contributed to this JabRef release: 
 
-[<img alt="Freeman6475" src="https://avatars.githubusercontent.com/u/96061552?v=4&s=117" width="117">](https://github.com/Freeman6475)[<img alt="MaryJml" src="https://avatars.githubusercontent.com/u/86668599?v=4&s=117" width="117">](https://github.com/MaryJml)[<img alt="Maformatiker" src="https://avatars.githubusercontent.com/u/26503503?v=4&s=117" width="117">](https://github.com/Maformatiker)[<img alt="mlep" src="https://avatars.githubusercontent.com/u/6931104?v=4&s=117" width="117">](https://github.com/mlep)
+[<img alt="Freeman6475" src="https://avatars.githubusercontent.com/u/96061552?v=4&s=117" width="117">](https://github.com/Freeman6475) |[<img alt="MaryJml" src="https://avatars.githubusercontent.com/u/86668599?v=4&s=117" width="117">](https://github.com/MaryJml) |[<img alt="Maformatiker" src="https://avatars.githubusercontent.com/u/26503503?v=4&s=117" width="117">](https://github.com/Maformatiker) |[<img alt="mlep" src="https://avatars.githubusercontent.com/u/6931104?v=4&s=117" width="117">](https://github.com/mlep) |
+:---: |:---: |:---: |:---: |
+[Freeman6475](https://github.com/Freeman6475) |[MaryJml](https://github.com/MaryJml) |[Maformatiker](https://github.com/Maformatiker) |[mlep](https://github.com/mlep) |

--- a/_posts/2022-12-18-JabRef5-9.md
+++ b/_posts/2022-12-18-JabRef5-9.md
@@ -28,7 +28,6 @@ In case you notice any bugs or problems, please browse through our [bug tracker]
 
 ## Special Thanks
 
-The [JabRef Maintainers](https://github.com/JabRef/jabref/blob/main/MAINTAINERS) would like to give special thanks to all contributors and people who donated to JabRef in the last year. Thank you very much for your appreciation!
+Following external contriubtors contributed to this JabRef release: 
 
-We also want to thank all universities [including JabRef in their academic teaching](https://devdocs.jabref.org/teaching).
-Finally, we would like to thank all the users who are constantly testing the latest snapshots and giving feedback!
+[<img alt="Freeman6475" src="https://avatars.githubusercontent.com/u/96061552?v=4&s=117" width="117">](https://github.com/Freeman6475)[<img alt="MaryJml" src="https://avatars.githubusercontent.com/u/86668599?v=4&s=117" width="117">](https://github.com/MaryJml)[<img alt="Maformatiker" src="https://avatars.githubusercontent.com/u/26503503?v=4&s=117" width="117">](https://github.com/Maformatiker)[<img alt="mlep" src="https://avatars.githubusercontent.com/u/6931104?v=4&s=117" width="117">](https://github.com/mlep)

--- a/_posts/2022-12-18-JabRef5-9.md
+++ b/_posts/2022-12-18-JabRef5-9.md
@@ -28,6 +28,6 @@ In case you notice any bugs or problems, please browse through our [bug tracker]
 
 ## Special Thanks
 
-Following external contriubtors contributed to this JabRef release: 
+Following external contributors contributed to this JabRef release: 
 
 [<img alt="Freeman6475" src="https://avatars.githubusercontent.com/u/96061552?v=4&s=117" width="117">](https://github.com/Freeman6475)[<img alt="MaryJml" src="https://avatars.githubusercontent.com/u/86668599?v=4&s=117" width="117">](https://github.com/MaryJml)[<img alt="Maformatiker" src="https://avatars.githubusercontent.com/u/26503503?v=4&s=117" width="117">](https://github.com/Maformatiker)[<img alt="mlep" src="https://avatars.githubusercontent.com/u/6931104?v=4&s=117" width="117">](https://github.com/mlep)


### PR DESCRIPTION
Our blog for v5.8 contained following image + text

![image](https://user-images.githubusercontent.com/1366654/210791698-a2e158da-b728-4510-9527-18c298c2a1f8.png)

(looks nice, doesn't it?)

I shortened the text and placed images:

![image](https://user-images.githubusercontent.com/1366654/210791572-e847b27c-1353-4ad9-b147-44e5a07e5cdf.png)

However, no one of the contributors has real images. Nevertheless, I would put it.

(Similar to https://github.com/JabRef/blog.jabref.org/pull/67)