### PR TITLE
Hotfix: Hamburger menu

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -91,7 +91,7 @@ avatar: img/JabRef-icon-256.png
 avatar_link: https://www.jabref.org
 
 # boolean type, the global switch for ToC in posts.
-toc: false
+toc: true
 
 comments:
   active:         # The global switch for posts comments, e.g., 'disqus'.  Keep it empty means disable


### PR DESCRIPTION
The absence of toc causes th ## tagged headings to bug and somehow disable the hamburger menu:
```
document.querySelector("main h2, main h3") && (tocbot.init({
    tocSelector: "#toc",
    contentSelector: ".content",
    ignoreSelector: "[data-toc-skip]",
    headingSelector: "h2, h3, h4",
    orderedList: !1,
    scrollSmooth: !1
}),
document.getElementById("toc-wrapper").classList.remove("d-none"))
```

Difference from minimal chirpy theme was the bool flag that enabled toc:
![image](https://github.com/user-attachments/assets/6bc5b052-4ab5-4927-9993-568698dc61a8)
