### PR TITLE
Add link to JabRef 6.0 Alpha2 release

### DIFF
--- a/_posts/2025-05-06-JabRef6-0-alpha2.md
+++ b/_posts/2025-05-06-JabRef6-0-alpha2.md
@@ -68,7 +68,7 @@ Be aware that currently the [update notification is broken](https://github.com/J
 
 ## Feedback and Testing
 
-If you'd like to to try JabRef 6.0 Alpha2, you can download it from [JabRef releases on Github](https://github.com/JabRef/jabref/releases).
+If you'd like to to try JabRef 6.0 Alpha2, you can download it from [the release page on GitHub](https://github.com/JabRef/jabref/releases/tag/v6.0-alpha2).
 We’re keen to hear your feedback! Please report bugs, suggestions, or feature requests on our [GitHub issue tracker](https://github.com/JabRef/jabref/issues) or join the discussion in our [discussion board](https://discourse.jabref.org/), in our [gitter-channel](https://gitter.im/JabRef/jabref) or on [Mastodon](https://foojay.social/@jabref).
 Finally we want to thank again all donors of time and money for their generous donations which enable us to continue working on JabRef!
 

--- a/_posts/2025-05-06-JabRef6-0-alpha2.md
+++ b/_posts/2025-05-06-JabRef6-0-alpha2.md
@@ -64,12 +64,13 @@ There are many more changes to check out. Take a look at the full [changelog](ht
 
 This is an alpha release, and we are still actively working on multiple issues. Some of them may be a regression to the last stable minor release of the 5 major series. Use the alpha release for testing only, and do not forget to backup your libraries.
 
-Be aware that currently the [update notification is broken](https://github.com/JabRef/jabref/issues/13000). It will inform you that a new version of JabRef is available, even though you have downloaded the latest release. Just ignore this message and the version.
+Be aware that currently the [update notification is broken](https://github.com/JabRef/jabref/issues/13000). It will inform you that a new version of JabRef is available, even though you have downloaded the latest release. Just ignore the notification.
 
 ## Feedback and Testing
 
+If you'd like to to try JabRef 6.0 Alpha2, you can download it from [JabRef releases on Github](https://github.com/JabRef/jabref/releases).
 We’re keen to hear your feedback! Please report bugs, suggestions, or feature requests on our [GitHub issue tracker](https://github.com/JabRef/jabref/issues) or join the discussion in our [discussion board](https://discourse.jabref.org/), in our [gitter-channel](https://gitter.im/JabRef/jabref) or on [Mastodon](https://foojay.social/@jabref).
-Finally we want to thank again all donators of time and money for their generous donations which enables us to continue working on JabRef!
+Finally we want to thank again all donors of time and money for their generous donations which enable us to continue working on JabRef!
 
 Thank you for testing JabRef 6.0 Alpha2, and remember to make a backup of your libraries first! 💙
 


### PR DESCRIPTION
Touch up wording and add link to JabRef 6.0 Alpha2 release.