### PR TITLE
Add blog post: How to use JabRef LSP with Emacs

### DIFF
--- a/_posts/2025-12-20-emacs-lsp-howto.md
+++ b/_posts/2025-12-20-emacs-lsp-howto.md
@@ -1,0 +1,124 @@
+---
+title: "How to use JabRef LSP with Emacs"
+author: Abilashini
+date: 2025-12-20
+tags: [emacs, lsp, jabref]
+---
+
+This post explains how to use the **JabRef Language Server (LSP)** with **Emacs**.
+It is intended for users who want IDE-like features such as autocompletion,
+navigation, and diagnostics while editing **BibTeX** files in Emacs.
+
+---
+
+## What is Emacs?
+
+Emacs is a powerful and highly customizable text editor.
+It is popular among developers and researchers because it can be extended
+using Emacs Lisp and supports advanced workflows.
+
+---
+
+## What is LSP?
+
+The **Language Server Protocol (LSP)** allows editors to provide features like:
+
+- Code completion
+- Error checking
+- Navigation
+- Documentation lookup
+
+These features are provided by a *language server*, not the editor itself.
+
+---
+
+## How JabRef LSP works with Emacs
+
+JabRef includes a **built-in LSP server** for BibTeX files.
+
+- Emacs acts as the **LSP client**
+- JabRef acts as the **LSP server**
+- Communication happens via standard input/output
+
+This allows Emacs to understand BibTeX files using JabRef’s logic.
+
+---
+
+## Prerequisites
+
+- JabRef installed (with LSP support)
+- Emacs installed
+- Basic familiarity with Emacs
+
+---
+
+## Install lsp-mode in Emacs
+
+Emacs uses an LSP client called **lsp-mode**.
+
+Install it using the Emacs package manager:
+
+```elisp
+M-x package-install RET lsp-mode RET
+---
+
+## Configure JabRef LSP in Emacs
+
+JabRef provides a built-in language server that can be started from the JabRef application.
+To use it with Emacs, JabRef must be running.
+
+Open JabRef and enable the language server:
+
+1. Start JabRef
+2. Go to **Options → Preferences → Advanced**
+3. Enable **Language Server**
+4. Note the port number shown
+---
+
+## Configure Emacs to use JabRef LSP
+
+Add the following configuration to your Emacs init file (`~/.emacs` or `init.el`):
+
+```elisp
+(require 'lsp-mode)
+
+(add-hook 'bibtex-mode-hook #'lsp)
+
+(setq lsp-log-io nil)
+---
+
+## Configure Emacs to use JabRef LSP
+
+Add the following configuration to your Emacs init file (`~/.emacs` or `init.el`):
+
+```elisp
+(require 'lsp-mode)
+
+(add-hook 'bibtex-mode-hook #'lsp)
+
+(setq lsp-log-io nil)
+---
+
+## Configure Emacs to use JabRef LSP
+
+Add the following configuration to your Emacs init file (`~/.emacs` or `init.el`):
+
+```elisp
+(require 'lsp-mode)
+
+(add-hook 'bibtex-mode-hook #'lsp)
+
+(setq lsp-log-io nil)
+---
+
+## Start JabRef LSP and test in Emacs
+
+1. Make sure JabRef is installed and available in your system PATH.
+2. Open Emacs.
+3. Open any `.bib` file.
+4. Emacs will automatically start the JabRef LSP server via `lsp-mode`.
+
+If everything is set up correctly, you should see:
+- Autocompletion for BibTeX fields
+- Validation warnings for invalid entries
+- Navigation support for references


### PR DESCRIPTION
### **User description**
This PR adds a new blog post explaining how to use JabRef’s built-in Language Server Protocol (LSP) with Emacs.

It covers:
- What Emacs and LSP are
- How JabRef’s LSP works with Emacs
- Installing and enabling lsp-mode
- Using JabRef LSP features while editing BibTeX files

This addresses issue #14656.


___

### **PR Type**
Documentation


___

### **Description**
- Adds comprehensive blog post on JabRef LSP integration with Emacs

- Covers LSP concepts, installation, and configuration steps

- Includes prerequisites and testing instructions for users


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Blog Post Content"] --> B["What is Emacs?"]
  A --> C["What is LSP?"]
  A --> D["JabRef LSP Setup"]
  D --> E["Install lsp-mode"]
  D --> F["Configure JabRef"]
  D --> G["Configure Emacs"]
  G --> H["Test & Verify"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>2025-12-20-emacs-lsp-howto.md</strong><dd><code>New blog post on JabRef LSP Emacs integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

_posts/2025-12-20-emacs-lsp-howto.md

<ul><li>New blog post explaining JabRef LSP usage with Emacs editor<br> <li> Covers foundational concepts: Emacs, LSP, and their integration<br> <li> Provides step-by-step installation and configuration instructions<br> <li> Includes prerequisites, testing procedures, and expected features</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/blog.jabref.org/pull/130/files#diff-21a1f570bb1a81c4ce23dbad4f51c4134baac13334108d94edc329cc10ca62ed">+124/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

