### PR TITLE
Miscellaneous enhancements to blog post

### DIFF
--- a/_posts/2026-05-14-JabRef6-0-alpha6.md
+++ b/_posts/2026-05-14-JabRef6-0-alpha6.md
@@ -32,7 +32,7 @@ JabRef is participating in GSOC this summer with three projects:
 
 - [Zeyad Abdelfattah](https://github.com/ZiadAbdElFatah) will be working on "Improved handling of older documents with OCR and AI-powered tools."
 - [Hancong Zhang](https://github.com/pluto-han) will work on "Improved LibreOffice-JabRef integration" with one particular aspect of compatibility with other reference managers.
-- [Wanling FU](https://github.com/wanling0000) will work on improving startup times for our CLI-based tool JabKit by leveraging the power of Hashtag GraalVM.
+- [Wanling FU](https://github.com/wanling0000) will work on improving startup times for our CLI-based tool JabKit by leveraging the power of GraalVM.
 
 Stay tuned for more project updates during the summer.
 

--- a/_posts/2026-05-14-JabRef6-0-alpha6.md
+++ b/_posts/2026-05-14-JabRef6-0-alpha6.md
@@ -30,19 +30,19 @@ Apart from these, there were plenty of bug fixes across all parts of JabRef. Che
 
 JabRef is participating in GSOC this summer with three projects:
 
-- Zeyad Abdelfattah will be working on "Improved handling of older documents with OCR and AI-powered tools."
-- Hancong Zhang will work on "Improved LibreOffice-JabRef integration" with one particular aspect of compatibility with other reference managers.
-- Wanling FU will work on improving startup times for our CLI-based tool JabKit by leveraging the power of Hashtag GraalVM.
+- [Zeyad Abdelfattah](https://github.com/ZiadAbdElFatah) will be working on "Improved handling of older documents with OCR and AI-powered tools."
+- [Hancong Zhang](https://github.com/pluto-han) will work on "Improved LibreOffice-JabRef integration" with one particular aspect of compatibility with other reference managers.
+- [Wanling FU](https://github.com/wanling0000) will work on improving startup times for our CLI-based tool JabKit by leveraging the power of Hashtag GraalVM.
 
 Stay tuned for more project updates during the summer.
 
 ### Special Thanks
 
-This time a special thanks to [Terry Bollinger](https://terrybollinger.com/) for sponsoring JabRef!
+This time again a special thanks to [Terry Bollinger](https://terrybollinger.com/) for sponsoring JabRef!
 
-A special thanks to [@Maran23](https://github.com/Maran23) who fixes longstanding bugs in the UI framework JavaFX that surfaced in JabRef.
+A special thanks to [Marius Hanl](https://github.com/Maran23) who fixed long-standing bugs in the UI framework JavaFX that surfaced in JabRef.
 
-Another special shootout goes to the contributors [@faneesh](https://github.com/faneeshh) and [@LoayTarek5](https://github.com/LoayTarek5) who are working together on improving the SLR feature in JabRef and are supporting the JabRef maintainers with code reviews.
+Another special shoutout goes to the contributors [Faneesh Juneja](https://github.com/faneeshh) and [Loay Tarek Mostafa](https://github.com/LoayTarek5) who are working together on improving the SLR feature in JabRef and are supporting the JabRef maintainers with code reviews.
 
 It’s people like these who help keep this software going.
 


### PR DESCRIPTION
- Uniform full name + github linking for contributors
- Grammar and typo fixes
- "Hashtag GraalVM" -> "GraalVM"